### PR TITLE
fix(validation): wrong condition for required field

### DIFF
--- a/libs/form-builder/src/lib/utils/__tests__/error.util.spec.js
+++ b/libs/form-builder/src/lib/utils/__tests__/error.util.spec.js
@@ -1,0 +1,65 @@
+import { isStepInError } from '../error.util.ts';
+
+describe('isStepInError', () => {
+  let schema;
+  let errors;
+  let fieldsToCheckByStep;
+  let dirtyFields;
+  let defaultValues;
+
+  beforeEach(() => {
+    schema = {
+      fields: {
+        myField: {
+          id: 'myField',
+          type: 'text',
+          validation: {
+            required: {
+              value: false,
+              key: 'required',
+              message: 'please fill this field',
+            },
+          },
+        },
+      },
+      stepsById: ['step1'],
+      steps: {
+        step1: {
+          id: 'step1',
+          fieldsById: ['myField'],
+          submit: { label: 'submit' },
+        },
+      },
+    };
+    errors = {};
+    fieldsToCheckByStep = ['myField'];
+    dirtyFields = {};
+    defaultValues = {};
+  });
+
+  it('should return false if the field is empty and not required', () => {
+    const isInError = isStepInError({
+      schema,
+      errors,
+      fieldsToCheckByStep,
+      dirtyFields,
+      defaultValues,
+    });
+
+    expect(isInError).toBe(false);
+  });
+
+  it('should return true if the field is empty and required', () => {
+    schema.fields.myField.validation.required.value = true;
+
+    const isInError = isStepInError({
+      schema,
+      errors,
+      fieldsToCheckByStep,
+      dirtyFields,
+      defaultValues,
+    });
+
+    expect(isInError).toBe(true);
+  });
+});

--- a/libs/form-builder/src/lib/utils/error.util.ts
+++ b/libs/form-builder/src/lib/utils/error.util.ts
@@ -17,13 +17,13 @@ export const getFieldsToCheckByStep = ({
   return fieldsToCheck;
 };
 
-export const isFieldInError = ({ fieldToCheck, errors }: { fieldToCheck: string; errors: FieldErrors }) =>
+const isFieldInError = ({ fieldToCheck, errors }: { fieldToCheck: string; errors: FieldErrors }) =>
   !!(errors && errors[fieldToCheck]);
 
-export const isFieldRequired = ({ schema, fieldToCheck }: { schema: FormSchema; fieldToCheck: string }) =>
-  schema?.fields?.[fieldToCheck]?.validation?.[DEFAULT_RULES_NAMES.required];
+const isFieldRequired = ({ schema, fieldToCheck }: { schema: FormSchema; fieldToCheck: string }): boolean =>
+  !!schema?.fields?.[fieldToCheck]?.validation?.[DEFAULT_RULES_NAMES.required]?.value;
 
-export const isFieldNotDirtyAndEmpty = ({
+const isFieldNotDirtyAndEmpty = ({
   fieldToCheck,
   dirtyFields,
   defaultValues,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The condition to check if a field is required returns an object, which is always truthy. I fixed the issue by reading the `value` property of said object, which returns whether the field is required or not.

## How Has This Been Tested?

tested with unit tests and use of the pre-release in our internal repo

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
