### PR TITLE
chore(deps): widen peerDependencies for react and @hookform/devtools

### DIFF
--- a/libs/form-builder/package.json
+++ b/libs/form-builder/package.json
@@ -5,7 +5,7 @@
     "react-hook-form": "7.27.0"
   },
   "peerDependencies": {
-    "react": "17.0.2"
+    "react": "17.0.2 || ^18.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "11.2.6",

--- a/libs/form-context/package.json
+++ b/libs/form-context/package.json
@@ -2,7 +2,7 @@
   "name": "@bedrockstreaming/form-context",
   "version": "0.9.1",
   "peerDependencies": {
-    "react": "17.0.2",
+    "react": "17.0.2 || ^18.0.0",
     "@bedrockstreaming/form-builder": "0.8.1",
     "react-hook-form": "7.27.0"
   },

--- a/libs/form-redux/package.json
+++ b/libs/form-redux/package.json
@@ -3,8 +3,8 @@
   "version": "0.9.1",
   "peerDependencies": {
     "@bedrockstreaming/form-builder": "0.8.1",
-    "@hookform/devtools": "4.0.2",
-    "react": "17.0.2",
+    "@hookform/devtools": "^4.0.2",
+    "react": "17.0.2  || ^18.0.0",
     "react-hook-form": "7.27.0"
   },
   "devDependencies": {

--- a/libs/form-validation-rule-list/package.json
+++ b/libs/form-validation-rule-list/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.1",
   "dependencies": {},
   "peerDependencies": {
-    "react": "17.0.2",
+    "react": "17.0.2 || ^18.0.0",
     "@bedrockstreaming/form-builder": "0.8.1",
     "react-hook-form": "7.27.0"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## 🤔 Why?
When using theses packages with our app. The peerDependencies resolutions makes our package manager warn us about unmet peerDependencies. 

We want to be able to use react-i18n with React 18.

We want to be able to use eslint-plugin-i18n.

<!--
Explain here why the repository need this change, explain the US with your own words.
In case of technical user story, this is more than mandatory.

You could specify:
- links to updated library changelog
- links to related documentation/discussion
-->

## 💻 How?

We widen the peerDependencies specifier:
- We want to allow React 18 to work with react-i18n with '|| ^18.0.0'
- We want to allow any hookform/devtools version between 4.0.2 and 5.0.0 not included

<!--
Describe the changes you made in the PR, changes in directory/tree, installed dependencies.
You could also self comment your diff to help reviewer understand them.

ℹ️ made this change to ...
-->


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The peerDependencies resolutions makes our package manager warn us about unmet peerDependencies. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't been tested 🤷


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- [x] Dependencies

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
